### PR TITLE
[#174734407] Adapt new resolution form to mobile devices

### DIFF
--- a/assets/javascripts/discourse/templates/modal/resolution-ui-builder.hbs
+++ b/assets/javascripts/discourse/templates/modal/resolution-ui-builder.hbs
@@ -21,9 +21,10 @@
           {{input-tip validation=minNumOfOptionsValidation}}
         </div>
 
-        <div class="d-editor-preview resolution-form-preview">
-          {{cook-text this.previewText}}
-        </div>
+        <details class="d-editor-preview resolution-form-preview" open>
+          <summary>Resolution Preview</summary>
+          <div class="resolution-preview">{{cook-text this.previewText}}</div>
+        </details>
       </div>
 
     </form>

--- a/assets/javascripts/discourse/templates/modal/resolution-ui-builder.hbs
+++ b/assets/javascripts/discourse/templates/modal/resolution-ui-builder.hbs
@@ -22,7 +22,7 @@
         </div>
 
         <details class="d-editor-preview resolution-form-preview" open>
-          <summary>Resolution Preview</summary>
+          <summary>{{i18n "communitarian.resolution.ui_builder.preview_title"}}</summary>
           <div class="resolution-preview">{{cook-text this.previewText}}</div>
         </details>
       </div>

--- a/assets/stylesheets/common/resolution-form.scss
+++ b/assets/stylesheets/common/resolution-form.scss
@@ -53,10 +53,20 @@
       label {
         font-weight: normal;
       }
+
+      @media screen and (max-width: 500px) {
+        .options {
+          width: 100%;
+        }
+      }
     }
 
     .body-content {
       display: flex;
+
+      @media screen and (max-width: 500px) {
+        flex-direction: column;
+      }
     }
 
     .options {
@@ -64,6 +74,10 @@
 
       .poll-textarea label {
         font-weight: bold;
+      }
+
+      @media (max-width: 700px) {
+        width: 50%;
       }
     }
 
@@ -77,6 +91,22 @@
       background-color: #f0f0f0;
       border-radius: 5px;
       padding: 0 1.3em;
+
+      summary {
+        @media (min-width: 500px) {
+          display: none;
+        }
+
+        @media (max-width: 500px) {
+          display: block;
+        }
+
+        &:before {
+          font-size: 11px;
+          margin-left: -10px;
+          margin-right: 5px;
+        }
+      }
 
       p {
         margin-bottom: 0;
@@ -100,6 +130,18 @@
         .poll-info {
           display: none;
         }
+      }
+
+      @media (max-width: 700px) {
+        width: 100%;
+        max-width: 50%;
+      }
+      
+      @media (max-width: 500px) {
+        margin-left: 0;
+        padding: .5em 1.3em .3em;
+        width: 100%;
+        max-width: 100%;
       }
     }
   }

--- a/assets/stylesheets/common/resolution-form.scss
+++ b/assets/stylesheets/common/resolution-form.scss
@@ -5,6 +5,7 @@
 
   .modal-body {
     padding: 1.5em 2em 2.5em;
+    max-height: none;
 
     @media screen and (max-width: 500px) {
       padding: 1.5em 1em 0.5em;
@@ -49,6 +50,10 @@
 
     .poll-ui-builder-form {
       display: block;
+
+      .d-editor-preview {
+        display: block;
+      }
 
       label {
         font-weight: normal;
@@ -124,6 +129,18 @@
 
           li[data-poll-option-id] {
             padding-bottom: 0;
+
+            &:before {
+              position: relative;
+              vertical-align: baseline;
+              border: 2px solid $primary;
+              border-radius: 50%;
+              display: inline-block;
+              margin-right: 0.5em;
+              width: 12px;
+              height: 12px;
+              content: "";
+            }
           }
         }
 
@@ -136,11 +153,10 @@
         width: 100%;
         max-width: 50%;
       }
-      
+
       @media (max-width: 500px) {
         margin-left: 0;
-        padding: .5em 1.3em .3em;
-        width: 100%;
+        padding: 0.5em 1.3em 0.3em;
         max-width: 100%;
       }
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -51,6 +51,7 @@ en:
           poll_options:
             label: Enter resolution options per line
             close_option: Close the poll
+          preview_title: Resolution Preview
         error_while_creating: Sorry, there was an error creating the resolution.
         error_while_updating: Sorry, there was an error updating the resolution.
         list:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/174734407

- Adapt new resolution form to mobile devices
- Make collapsible resolution preview on mobile devices

<img width="339" alt="Снимок экрана 2020-09-14 в 13 02 12" src="https://user-images.githubusercontent.com/46020998/93073439-9c37a180-f68b-11ea-80e2-a81e4c21c006.png">
