### PR TITLE
[#174649826] About page changes

### DIFF
--- a/assets/stylesheets/common/about-page.scss
+++ b/assets/stylesheets/common/about-page.scss
@@ -1,0 +1,7 @@
+section.about.admins {
+  display: none;
+}
+
+section.about.stats {
+  display: none;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,7 @@ require "stripe"
 enabled_site_setting :communitarian_enabled
 
 [
+  "stylesheets/common/about-page.scss",
   "stylesheets/common/resolution-form.scss",
   "stylesheets/common/landing.scss",
   "stylesheets/common/communities-page.scss",


### PR DESCRIPTION
Removes admins and stats sections from about page.

https://www.pivotaltracker.com/story/show/174649826

