### PR TITLE
[#175181834] Hide tags from ongoing dialogs

### DIFF
--- a/assets/javascripts/discourse/templates/list/topic-list-item.hbr
+++ b/assets/javascripts/discourse/templates/list/topic-list-item.hbr
@@ -40,8 +40,8 @@
     <a class="bottom-line-activity" href="{{topic.lastPostUrl}}">
       {{~topic.bumped_at~}}
     </a>
+    {{!-- {{discourse-tags topic mode="list" tagsForUser=tagsForUser}} --}}
     {{!-- /custom code --}}
-    {{discourse-tags topic mode="list" tagsForUser=tagsForUser}}
     {{raw "list/action-list" topic=topic postNumbers=topic.liked_post_numbers className="likes" icon="heart"}}
   </div>
   {{#if expandPinned}}

--- a/assets/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
+++ b/assets/javascripts/discourse/templates/mobile/list/topic-list-item.hbr
@@ -40,7 +40,9 @@
               {{category-link topic.category}}
             </div>
           {{/unless}}
-          {{discourse-tags topic mode="list"}}
+          {{!-- custom code --}}
+          {{!-- {{discourse-tags topic mode="list"}} --}}
+          {{!-- /custom code --}}
           <div class="pull-right">
             <div class='num activity last'>
               <span class="age activity" title="{{topic.bumpedAtTitle}}">


### PR DESCRIPTION
Task: [hide tags from ongoing dialogs list](https://www.pivotaltracker.com/story/show/175181834)

Before
<img width="738" alt="Снимок экрана 2020-10-08 в 18 37 13" src="https://user-images.githubusercontent.com/46020998/95481147-5a9dcc00-0995-11eb-807e-8e74ada3872a.png">


After
<img width="739" alt="Снимок экрана 2020-10-08 в 18 37 30" src="https://user-images.githubusercontent.com/46020998/95481164-6093ad00-0995-11eb-9f02-9861ab83c1f4.png">


