### PR TITLE
[#175202111] Can't create resolution from ongoing dialogs page

### DIFF
--- a/assets/javascripts/controllers/resolution-ui-builder.js.es6
+++ b/assets/javascripts/controllers/resolution-ui-builder.js.es6
@@ -96,7 +96,7 @@ export default Controller.extend({
 
   _setupPoll(postId = null) {
     if (postId === null) {
-      let slug = window.location.pathname.match(/c\/.*\/(.*)$/);
+      let slug = window.location.pathname.match(/c\/[^\/]*\/(\d).*$/);
       this.setProperties({
         action: "create",
         buttonLabel: "communitarian.resolution.ui_builder.create",

--- a/assets/javascripts/controllers/resolution-ui-builder.js.es6
+++ b/assets/javascripts/controllers/resolution-ui-builder.js.es6
@@ -96,7 +96,7 @@ export default Controller.extend({
 
   _setupPoll(postId = null) {
     if (postId === null) {
-      let slug = window.location.pathname.match(/c\/[^\/]*\/(\d).*$/);
+      let slug = window.location.pathname.match(/c\/[^\/]*\/(\d+).*$/);
       this.setProperties({
         action: "create",
         buttonLabel: "communitarian.resolution.ui_builder.create",

--- a/assets/javascripts/discourse/templates/discovery/topics.hbs
+++ b/assets/javascripts/discourse/templates/discovery/topics.hbs
@@ -53,7 +53,7 @@
   {{plugin-outlet name="before-topic-list" args=(hash category=category)}}
 
   {{!-- custom code started here ↓ --}}
-  {{#if hasDialogs}}
+  {{#if hasTopics}}
     <h2>{{i18n "communitarian.resolution.header_title"}}</h2>
     {{community-details
       highlightLastVisited=true
@@ -78,7 +78,7 @@
       scrollOnLoad=true
       onScroll=discoveryTopicList.saveScrollPosition}}
   {{else}}
-    {{#if hasTopics}}
+    {{#if hasDialogs}}
       <h2>{{i18n "communitarian.dialogs.header_title"}}</h2>
       {{topic-list
         class="dialog-list-page-content"


### PR DESCRIPTION
Task: [Can't create resolution from ongoing dialogs page](https://www.pivotaltracker.com/story/show/175202111)

****Description****
The bug was in the incorrect extraction of the category id from the pathname. On the resolution page (pathname: `/c/staff/3`) category id was retrieved correctly (`3`), but on the dialogs page (`/c/staff/3/l/dialogs`) it was not (`dialogs`).