### PR TITLE
[#175054230] Admin markup fix

### DIFF
--- a/assets/stylesheets/common/dialog-page.scss
+++ b/assets/stylesheets/common/dialog-page.scss
@@ -65,6 +65,10 @@
         .boxed {
           border-top: 0;
           padding-top: 0;
+
+          .post-notice {
+            display: none;
+          }
         }
 
         .cooked {


### PR DESCRIPTION
Task: [Admin markup fix](https://www.pivotaltracker.com/story/show/175054230)

****Before****
<img width="950" alt="Снимок экрана 2020-10-09 в 13 05 20" src="https://user-images.githubusercontent.com/46020998/95605731-09a7d980-0a62-11eb-8076-df5a5230e43a.png">


****After****
<img width="746" alt="Снимок экрана 2020-10-09 в 19 00 39" src="https://user-images.githubusercontent.com/46020998/95605773-16c4c880-0a62-11eb-9a5c-67d1aea08765.png">
