### PR TITLE
[#175116603] Show edit button on resolutions page mobile

### DIFF
--- a/assets/javascripts/discourse/templates/navigation/category.hbs
+++ b/assets/javascripts/discourse/templates/navigation/category.hbs
@@ -22,6 +22,23 @@
             label="communitarian.dialogs.dialogs_link"
             class="link-button--dialogs page-header__button"
           }}
+          {{#if category.can_edit}}
+            {{#if currentUser.staff}}
+              {{d-button
+                class="btn-default edit-category page-header__button"
+                action=(route-action "editCategory" category)
+                icon="wrench"
+                label="category.edit"
+              }}
+            {{else}}
+              {{d-button
+                class="btn-default edit-category page-header__button"
+                action=(action "editCommunity" category)
+                icon="wrench"
+                label="category.edit"
+              }}
+            {{/if}}
+          {{/if}}
           {{new-topic-dropdown
             class="page-header__button"
             createDialog=(route-action "createTopic")


### PR DESCRIPTION
Task: [ongoing dialogue list should be full widthв](https://www.pivotaltracker.com/story/show/175116603)

****Before****
<img width="378" alt="Снимок экрана 2020-10-09 в 19 22 22" src="https://user-images.githubusercontent.com/46020998/95607710-cdc24380-0a64-11eb-8c8a-37e9ab6a7e74.png">


****After****
<img width="345" alt="Снимок экрана 2020-10-09 в 19 22 11" src="https://user-images.githubusercontent.com/46020998/95607732-d581e800-0a64-11eb-8bb3-845f0ce4a9a0.png">
